### PR TITLE
Sort (empty) setups alphabetically, so they are sorted since the start

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -75,32 +75,30 @@ const TableBody = ({ setups, tab, setupKeysToShow }: TableBodyProps): ReactEleme
         setups.length > 0 &&
         empty_setup.map((default_content: SetupProps, key: number) => (
           <React.Fragment key={key}>
-            {default_content.tab === tab && (
-              <Tr>
-                {setups?.map((setup: SetupCompleteProps, key2: number) => {
-                  const setup_content_in_current_key: SetupProps | undefined = setup.content.find(
-                    (content: SetupProps) => content.key === default_content.key,
-                  )
+            {default_content.tab === tab &&
+              setupKeysToShow.find((line: SetupKeysToShowProps) => line.key === default_content.key)
+                ?.show && (
+                <Tr>
+                  {setups?.map((setup: SetupCompleteProps, key2: number) => {
+                    const setup_content_in_current_key: SetupProps | undefined = setup.content.find(
+                      (content: SetupProps) => content.key === default_content.key,
+                    )
 
-                  const show = setupKeysToShow.find(
-                    (line: SetupKeysToShowProps) => line.key === default_content.key,
-                  )?.show
-
-                  return (
-                    <React.Fragment key={key2}>
-                      {default_content.key === setup_content_in_current_key?.key && show && (
-                        <>
-                          {key2 === 0 && <Th>{`${default_content.name}`}</Th>}
-                          <Td style={{ textAlign: 'center', whiteSpace: 'pre-wrap' }}>
-                            {`${setup_content_in_current_key?.value}`}
-                          </Td>
-                        </>
-                      )}
-                    </React.Fragment>
-                  )
-                })}
-              </Tr>
-            )}
+                    return (
+                      <React.Fragment key={key2}>
+                        {default_content.key === setup_content_in_current_key?.key && (
+                          <>
+                            {key2 === 0 && <Th>{`${default_content.name}`}</Th>}
+                            <Td style={{ textAlign: 'center', whiteSpace: 'pre-wrap' }}>
+                              {`${setup_content_in_current_key?.value}`}
+                            </Td>
+                          </>
+                        )}
+                      </React.Fragment>
+                    )
+                  })}
+                </Tr>
+              )}
           </React.Fragment>
         ))
     }

--- a/src/setup.tsx
+++ b/src/setup.tsx
@@ -826,6 +826,11 @@ const empty_setup_without_value: SetupWithoutValueProps[] = [
   },
 ]
 
-export const empty_setup: SetupProps[] = empty_setup_without_value.map(
+const unordered_empty_setup: SetupProps[] = empty_setup_without_value.map(
   (content: SetupWithoutValueProps) => ({ ...content, value: '' }),
+)
+
+// sort setups
+export const empty_setup: SetupProps[] = unordered_empty_setup.sort(
+  (a: SetupProps, b: SetupProps) => (a.name > b.name ? 1 : -1),
 )


### PR DESCRIPTION
## 📄 Related issue
#28

## 📝 Proposed changes
Sort (empty) setups alphabetically, so they are sorted since the start

<!-- ## ℹ️ Additional info
If needed add any other things to note -->

<!-- ## ✅ Checklist
If you need a checklist to mark completed tasks -->
<!--
- [ ] item 1
- [ ] item 2
-->

<!--## 🖼 Screenshots
If it adds value to put a before and after screenshots
** Before **

** After **
-->